### PR TITLE
Add persistence layer tests

### DIFF
--- a/cmd/ircserver/main_test.go
+++ b/cmd/ircserver/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -162,8 +163,8 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			nickname := "user" + string(i)
-			err := store.UpdateUser(ctx, nickname, nickname, "User "+string(i), "127.0.0.1")
+			nickname := "user" + strconv.Itoa(i)
+			err := store.UpdateUser(ctx, nickname, nickname, "User "+strconv.Itoa(i), "127.0.0.1")
 			if err != nil {
 				t.Errorf("Failed to update user %d: %v", i, err)
 			}

--- a/cmd/ircserver/main_test.go
+++ b/cmd/ircserver/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,7 +69,7 @@ func TestUserPersistence(t *testing.T) {
 
 	var nickname, username, realname, ipAddress string
 	var lastSeen time.Time
-	err = store.db.QueryRowContext(ctx, "SELECT nickname, username, realname, ip_address, last_seen FROM users WHERE nickname = ?", "testuser").Scan(&nickname, &username, &realname, &ipAddress, &lastSeen)
+	err = store.QueryRow(ctx, "SELECT nickname, username, realname, ip_address, last_seen FROM users WHERE nickname = ?", "testuser").Scan(&nickname, &username, &realname, &ipAddress, &lastSeen)
 	if err != nil {
 		t.Fatalf("Failed to query user: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestChannelPersistence(t *testing.T) {
 
 	var name, topic string
 	var createdAt time.Time
-	err = store.db.QueryRowContext(ctx, "SELECT name, topic, created_at FROM channels WHERE name = ?", "#testchannel").Scan(&name, &topic, &createdAt)
+	err = store.QueryRow(ctx, "SELECT name, topic, created_at FROM channels WHERE name = ?", "#testchannel").Scan(&name, &topic, &createdAt)
 	if err != nil {
 		t.Fatalf("Failed to query channel: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestMessageLogging(t *testing.T) {
 
 	var timestamp time.Time
 	var sender, recipient, msgType, content string
-	err = store.db.QueryRowContext(ctx, "SELECT timestamp, sender, recipient, message_type, content FROM message_logs WHERE sender = ?", "sender").Scan(&timestamp, &sender, &recipient, &msgType, &content)
+	err = store.QueryRow(ctx, "SELECT timestamp, sender, recipient, message_type, content FROM message_logs WHERE sender = ?", "sender").Scan(&timestamp, &sender, &recipient, &msgType, &content)
 	if err != nil {
 		t.Fatalf("Failed to query message log: %v", err)
 	}
@@ -172,7 +173,7 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 	wg.Wait()
 
 	var count int
-	err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
+	err := store.QueryRow(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
 	if err != nil {
 		t.Fatalf("Failed to count users: %v", err)
 	}

--- a/internal/persistence/sqlite.go
+++ b/internal/persistence/sqlite.go
@@ -10,20 +10,6 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-// Store defines the interface for persistence operations.
-type Store interface {
-	// Close closes the underlying database connection
-	Close() error
-
-	// LogMessage stores a message in the database
-	LogMessage(ctx context.Context, sender, recipient, msgType, content string) error
-
-	// UpdateUser stores or updates user information
-	UpdateUser(ctx context.Context, nickname, username, realname, ipAddr string) error
-
-	// UpdateChannel stores or updates channel information
-	UpdateChannel(ctx context.Context, name, topic string) error
-}
 
 // Ensure SQLiteStore implements Store interface.
 var _ Store = (*SQLiteStore)(nil)

--- a/internal/persistence/sqlite.go
+++ b/internal/persistence/sqlite.go
@@ -35,6 +35,7 @@ type SQLiteStore struct {
 
 // New creates a new database connection and initializes tables.
 func New(dbPath string) (*SQLiteStore, error) {
+	store := &SQLiteStore{}
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %v", err)
@@ -45,7 +46,8 @@ func New(dbPath string) (*SQLiteStore, error) {
 		return nil, err
 	}
 
-	return &SQLiteStore{db: db}, nil
+	store.db = db
+	return store, nil
 }
 
 // Close closes the database connection.

--- a/internal/persistence/sqlite.go
+++ b/internal/persistence/sqlite.go
@@ -10,6 +10,21 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// Store defines the interface for persistence operations.
+type Store interface {
+	// Close closes the underlying database connection
+	Close() error
+
+	// LogMessage stores a message in the database
+	LogMessage(ctx context.Context, sender, recipient, msgType, content string) error
+
+	// UpdateUser stores or updates user information
+	UpdateUser(ctx context.Context, nickname, username, realname, ipAddr string) error
+
+	// UpdateChannel stores or updates channel information
+	UpdateChannel(ctx context.Context, name, topic string) error
+}
+
 // Ensure SQLiteStore implements Store interface.
 var _ Store = (*SQLiteStore)(nil)
 

--- a/internal/persistence/sqlite.go
+++ b/internal/persistence/sqlite.go
@@ -110,3 +110,9 @@ func (s *SQLiteStore) UpdateChannel(ctx context.Context, name, topic string) err
 	}
 	return err
 }
+
+// QueryRow executes a query that returns a single row and scans the result into dest.
+// This method is primarily intended for testing.
+func (s *SQLiteStore) QueryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return s.db.QueryRowContext(ctx, query, args...)
+}

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -1,55 +1,18 @@
-package main
+package persistence
 
 import (
 	"context"
-	"os"
+	"database/sql"
+	"sync"
 	"testing"
 	"time"
 
-	"ircserver/internal/persistence"
+	_ "github.com/mattn/go-sqlite3"
 )
 
-func TestGetEnv(t *testing.T) {
-	tests := []struct {
-		name     string
-		key      string
-		envValue string
-		fallback string
-		want     string
-	}{
-		{
-			name:     "returns fallback when env not set",
-			key:      "TEST_KEY",
-			envValue: "",
-			fallback: "default",
-			want:     "default",
-		},
-		{
-			name:     "returns env value when set",
-			key:      "TEST_KEY",
-			envValue: "custom",
-			fallback: "default",
-			want:     "custom",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
-				os.Setenv(tt.key, tt.envValue)
-				defer os.Unsetenv(tt.key)
-			}
-
-			if got := getEnv(tt.key, tt.fallback); got != tt.want {
-				t.Errorf("getEnv() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func setupTestDB(t *testing.T) *persistence.SQLiteStore {
+func setupTestDB(t *testing.T) *SQLiteStore {
 	t.Helper()
-	db, err := persistence.New(":memory:")
+	db, err := New(":memory:")
 	if err != nil {
 		t.Fatalf("Failed to create test database: %v", err)
 	}

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -2,7 +2,7 @@ package persistence
 
 import (
 	"context"
-	"database/sql"
+
 	"sync"
 	"testing"
 	"time"

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -176,7 +176,7 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 	wg.Wait()
 
 	var count int
-	err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
+	err = store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
 	if err != nil {
 		t.Fatalf("Failed to count users: %v", err)
 	}

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"context"
-	"database/sql"
 	"strconv"
 	"sync"
 	"testing"

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -148,13 +148,13 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 
 	// Verify tables exist by checking the schema
 	var tableName string
-	err := store.db.QueryRowContext(ctx, "SELECT name FROM sqlite_master WHERE type='table' AND name='users'").Scan(&tableName)
+	err = store.db.QueryRowContext(ctx, "SELECT name FROM sqlite_master WHERE type='table' AND name='users'").Scan(&tableName)
 	if err != nil {
 		t.Fatalf("Failed to verify users table exists: %v", err)
 	}
 
 	// Initialize with test data
-	if err := store.UpdateUser(ctx, "init", "init", "Initial User", "127.0.0.1"); err != nil {
+	if err = store.UpdateUser(ctx, "init", "init", "Initial User", "127.0.0.1"); err != nil {
 		t.Fatalf("Failed to initialize database: %v", err)
 	}
 

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -140,16 +140,16 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 	defer store.Close()
 
 	ctx := context.Background()
+	var err error
 	
 	// Explicitly create tables and verify they exist
-	if err := createTables(store.db); err != nil {
+	if err = createTables(store.db); err != nil {
 		t.Fatalf("Failed to create tables: %v", err)
 	}
 
 	// Verify tables exist by checking the schema
 	var tableName string
-	err = store.db.QueryRowContext(ctx, "SELECT name FROM sqlite_master WHERE type='table' AND name='users'").Scan(&tableName)
-	if err != nil {
+	if err = store.db.QueryRowContext(ctx, "SELECT name FROM sqlite_master WHERE type='table' AND name='users'").Scan(&tableName); err != nil {
 		t.Fatalf("Failed to verify users table exists: %v", err)
 	}
 

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -12,11 +12,18 @@ import (
 
 func setupTestDB(t *testing.T) *SQLiteStore {
 	t.Helper()
-	db, err := New(":memory:")
+	store := &SQLiteStore{}
+	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatalf("Failed to create test database: %v", err)
 	}
-	return db
+	store.db = db
+	
+	if err := createTables(db); err != nil {
+		db.Close()
+		t.Fatalf("Failed to create tables: %v", err)
+	}
+	return store
 }
 
 func TestUserPersistence(t *testing.T) {

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 	"sync"
 	"testing"

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -139,7 +139,12 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 	store := setupTestDB(t)
 	defer store.Close()
 
+	// Ensure tables exist by doing an initial insert
 	ctx := context.Background()
+	if err := store.UpdateUser(ctx, "init", "init", "Initial User", "127.0.0.1"); err != nil {
+		t.Fatalf("Failed to initialize database: %v", err)
+	}
+
 	var wg sync.WaitGroup
 	numGoroutines := 10
 

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -2,7 +2,7 @@ package persistence
 
 import (
 	"context"
-
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -124,8 +124,8 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			nickname := "user" + string(i)
-			err := store.UpdateUser(ctx, nickname, nickname, "User "+string(i), "127.0.0.1")
+			nickname := "user" + strconv.Itoa(i)
+			err := store.UpdateUser(ctx, nickname, nickname, "User "+strconv.Itoa(i), "127.0.0.1")
 			if err != nil {
 				t.Errorf("Failed to update user %d: %v", i, err)
 			}

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -13,18 +13,11 @@ import (
 
 func setupTestDB(t *testing.T) *SQLiteStore {
 	t.Helper()
-	store := &SQLiteStore{}
-	db, err := sql.Open("sqlite3", ":memory:")
+	db, err := New(":memory:")
 	if err != nil {
 		t.Fatalf("Failed to create test database: %v", err)
 	}
-	store.db = db
-	
-	if err := createTables(db); err != nil {
-		db.Close()
-		t.Fatalf("Failed to create tables: %v", err)
-	}
-	return store
+	return db
 }
 
 func TestUserPersistence(t *testing.T) {

--- a/internal/persistence/sqlite_test.go
+++ b/internal/persistence/sqlite_test.go
@@ -139,8 +139,21 @@ func TestConcurrentDatabaseAccess(t *testing.T) {
 	store := setupTestDB(t)
 	defer store.Close()
 
-	// Ensure tables exist by doing an initial insert
 	ctx := context.Background()
+	
+	// Explicitly create tables and verify they exist
+	if err := createTables(store.db); err != nil {
+		t.Fatalf("Failed to create tables: %v", err)
+	}
+
+	// Verify tables exist by checking the schema
+	var tableName string
+	err := store.db.QueryRowContext(ctx, "SELECT name FROM sqlite_master WHERE type='table' AND name='users'").Scan(&tableName)
+	if err != nil {
+		t.Fatalf("Failed to verify users table exists: %v", err)
+	}
+
+	// Initialize with test data
 	if err := store.UpdateUser(ctx, "init", "init", "Initial User", "127.0.0.1"); err != nil {
 		t.Fatalf("Failed to initialize database: %v", err)
 	}


### PR DESCRIPTION
Add tests for persistence layer operations.

* **User Persistence**: Add `TestUserPersistence` to test CRUD operations on users.
* **Channel Persistence**: Add `TestChannelPersistence` to test CRUD operations on channels.
* **Message Logging**: Add `TestMessageLogging` to test logging of messages.
* **Database Errors**: Add `TestDatabaseErrors` to test handling of unique constraint violations on users and channels.
* **Concurrent Database Access**: Add `TestConcurrentDatabaseAccess` to test concurrent access to the database.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2389-research/ircserver/pull/2?shareId=205af328-2c9b-4438-afbb-38d7833b9fe1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added comprehensive test suite for database operations
	- Introduced tests for user and channel persistence
	- Implemented tests for message logging
	- Added error handling and concurrent access tests
	- Ensured robust testing of SQLite database functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->