### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -107,3 +107,30 @@ jobs:
                   fi
             - name: Run tests with race detector
               run: go test -race -v ./...
+
+    integration_test:
+        name: Run Integration Tests
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v3.5.3
+            - name: Set up Go
+              uses: actions/setup-go@v4.0.1
+              with:
+                  go-version: "1.23.2"
+            - name: Cache Go modules
+              uses: actions/cache@v3.3.1
+              with:
+                  path: ~/go/pkg/mod
+                  key: ${{ runner.os }}-go-integration-${{ hashFiles('**/go.sum') }}
+                  restore-keys: |
+                      ${{ runner.os }}-go-integration-
+            - name: Verify dependencies
+              run: go mod verify
+            - name: Run go mod tidy
+              run: go mod tidy
+            - name: Install dependencies
+              run: go mod download
+            - name: Run integration tests
+              run: go test -v -tags=integration ./cmd/ircserver

--- a/cmd/ircserver/main_test.go
+++ b/cmd/ircserver/main_test.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"context"
+	"net"
 	"os"
 	"testing"
+	"time"
+
+	"ircserver/internal/config"
+	"ircserver/internal/persistence"
+	"ircserver/internal/server"
 )
 
 func TestGetEnv(t *testing.T) {
@@ -41,4 +48,170 @@ func TestGetEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIntegration(t *testing.T) {
+	cfg := config.DefaultConfig()
+	store, err := persistence.New(":memory:")
+	if err != nil {
+		t.Fatalf("Failed to initialize in-memory database: %v", err)
+	}
+	defer store.Close()
+
+	srv := server.New(cfg.Server.Host, cfg.Server.Port, store, cfg)
+	go func() {
+		if err := srv.Start(); err != nil {
+			t.Fatalf("Failed to start server: %v", err)
+		}
+	}()
+	defer srv.Shutdown()
+
+	time.Sleep(100 * time.Millisecond) // Give server time to start
+
+	t.Run("TestFullClientLifecycle", func(t *testing.T) {
+		conn, err := net.Dial("tcp", "localhost:6667")
+		if err != nil {
+			t.Fatalf("Failed to connect to server: %v", err)
+		}
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("NICK testuser\r\nUSER test 0 * :Test User\r\n"))
+		if err != nil {
+			t.Fatalf("Failed to send data: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // Give server time to process
+
+		// Check if user is registered
+		if _, exists := srv.Clients["testuser"]; !exists {
+			t.Fatalf("User not registered")
+		}
+	})
+
+	t.Run("TestMultipleClientsInteraction", func(t *testing.T) {
+		conn1, err := net.Dial("tcp", "localhost:6667")
+		if err != nil {
+			t.Fatalf("Failed to connect to server: %v", err)
+		}
+		defer conn1.Close()
+
+		conn2, err := net.Dial("tcp", "localhost:6667")
+		if err != nil {
+			t.Fatalf("Failed to connect to server: %v", err)
+		}
+		defer conn2.Close()
+
+		_, err = conn1.Write([]byte("NICK user1\r\nUSER test 0 * :User 1\r\n"))
+		if err != nil {
+			t.Fatalf("Failed to send data: %v", err)
+		}
+
+		_, err = conn2.Write([]byte("NICK user2\r\nUSER test 0 * :User 2\r\n"))
+		if err != nil {
+			t.Fatalf("Failed to send data: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // Give server time to process
+
+		// Check if users are registered
+		if _, exists := srv.Clients["user1"]; !exists {
+			t.Fatalf("User1 not registered")
+		}
+		if _, exists := srv.Clients["user2"]; !exists {
+			t.Fatalf("User2 not registered")
+		}
+
+		_, err = conn1.Write([]byte("JOIN #test\r\n"))
+		if err != nil {
+			t.Fatalf("Failed to send data: %v", err)
+		}
+
+		_, err = conn2.Write([]byte("JOIN #test\r\n"))
+		if err != nil {
+			t.Fatalf("Failed to send data: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // Give server time to process
+
+		// Check if users are in the channel
+		channel, exists := srv.Channels["#test"]
+		if !exists {
+			t.Fatalf("Channel not created")
+		}
+		if !channel.HasClient("user1") {
+			t.Fatalf("User1 not in channel")
+		}
+		if !channel.HasClient("user2") {
+			t.Fatalf("User2 not in channel")
+		}
+	})
+
+	t.Run("TestPersistenceAcrossRestarts", func(t *testing.T) {
+		conn, err := net.Dial("tcp", "localhost:6667")
+		if err != nil {
+			t.Fatalf("Failed to connect to server: %v", err)
+		}
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("NICK persistentuser\r\nUSER test 0 * :Persistent User\r\n"))
+		if err != nil {
+			t.Fatalf("Failed to send data: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // Give server time to process
+
+		// Check if user is registered
+		if _, exists := srv.Clients["persistentuser"]; !exists {
+			t.Fatalf("User not registered")
+		}
+
+		srv.Shutdown()
+		time.Sleep(100 * time.Millisecond) // Give server time to shutdown
+
+		srv = server.New(cfg.Server.Host, cfg.Server.Port, store, cfg)
+		go func() {
+			if err := srv.Start(); err != nil {
+				t.Fatalf("Failed to start server: %v", err)
+			}
+		}()
+		defer srv.Shutdown()
+
+		time.Sleep(100 * time.Millisecond) // Give server time to start
+
+		// Check if user is still registered
+		if _, exists := srv.Clients["persistentuser"]; !exists {
+			t.Fatalf("User not persisted")
+		}
+	})
+
+	t.Run("TestWebInterfaceIntegration", func(t *testing.T) {
+		webServer, err := server.NewWebServer(srv)
+		if err != nil {
+			t.Fatalf("Failed to initialize web server: %v", err)
+		}
+		go func() {
+			if err := webServer.Start(":8080"); err != nil {
+				t.Fatalf("Failed to start web server: %v", err)
+			}
+		}()
+		defer webServer.Shutdown()
+
+		time.Sleep(100 * time.Millisecond) // Give web server time to start
+
+		resp, err := http.Get("http://localhost:8080/api/data")
+		if err != nil {
+			t.Fatalf("Failed to get data from web interface: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Unexpected status code: %v", resp.StatusCode)
+		}
+	})
+
+	t.Run("TestWithRealIRCClients", func(t *testing.T) {
+		// This test requires a real IRC client to connect to the server
+		// and perform basic operations like NICK, USER, JOIN, PRIVMSG, etc.
+		// This can be done manually or using an automated IRC client library.
+	})
 }


### PR DESCRIPTION
Fixes #6

Add integration tests for full client lifecycle, interaction between multiple clients, persistence across restarts, web interface integration, and real IRC clients.

* **cmd/ircserver/main_test.go**
  - Add `TestIntegration` function.
  - Add test for full client lifecycle.
  - Add test for interaction between multiple clients.
  - Add test for persistence across restarts.
  - Add test for web interface integration.
  - Add placeholder for test with real IRC clients.

* **.github/workflows/go-tests.yaml**
  - Update to include running the new integration tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2389-research/ircserver/pull/11?shareId=b950e65b-eb63-4f55-ad8b-c9088628bcc1).