### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,47 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - ".github/**"
+      - "**.md"
+      - ".gitignore"
+      - ".mise.toml"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  integration_tests:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.5.3
+      - name: Set up Go
+        uses: actions/setup-go@v4.0.1
+        with:
+          go-version: "1.23.2"
+      - name: Cache Go modules
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-integration-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-integration-
+      - name: Verify dependencies
+        run: go mod verify
+      - name: Run go mod tidy
+        run: go mod tidy
+      - name: Install dependencies
+        run: go mod download
+      - name: Run integration tests
+        run: go test -v ./cmd/ircserver -run TestIntegration -coverprofile=integration-coverage.out -covermode=atomic
+      - name: Upload test results
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: integration-test-results
+          path: integration-coverage.out


### PR DESCRIPTION
Fixes #6

Add integration tests for the IRC server.

* **cmd/ircserver/main_test.go**
  - Add `TestIntegration` function to cover full client lifecycle, interaction between multiple clients, persistence across restarts, web interface integration, and real IRC clients.
  - Implement sub-tests for full client lifecycle, multiple clients interaction, persistence across restarts, and web interface integration.
  - Skip test for real IRC clients as it requires real IRC clients.

* **.github/workflows/integration-tests.yaml**
  - Create a new GitHub Actions workflow file for integration tests.
  - Add a job to run integration tests on `ubuntu-latest`.
  - Set up Go environment and dependencies.
  - Run integration tests and upload results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2389-research/ircserver/pull/14?shareId=487b3e75-2f97-479f-88ab-684600157395).