### PR TITLE
Fix IO timeout issue in IRC server

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,5 @@ storage:
 irc:
   default_channel: "#general"
   max_message_length: 512
+  max_retries: 3
+  retry_delay: 100ms

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 		WriteTimeout     time.Duration `yaml:"write_timeout"`
 		MaxBufferSize    int           `yaml:"max_buffer_size"`
 		IdleTimeout      time.Duration `yaml:"idle_timeout"`
+		MaxRetries      int           `yaml:"max_retries"`
+		RetryDelay      time.Duration `yaml:"retry_delay"`
 	} `yaml:"irc"`
 }
 
@@ -49,6 +51,8 @@ func DefaultConfig() *Config {
 	cfg.IRC.WriteTimeout = 60 * time.Second
 	cfg.IRC.MaxBufferSize = 4096
 	cfg.IRC.IdleTimeout = 600 * time.Second
+	cfg.IRC.MaxRetries = 3
+	cfg.IRC.RetryDelay = 1 * time.Second
 	return cfg
 }
 


### PR DESCRIPTION
Fixes #15

Add retry logic for handling IO timeouts when sending messages to clients.

* **config.yaml**
  - Add `max_retries` and `retry_delay` settings under `irc` section.

* **internal/server/client.go**
  - Add retry logic in `Send` method to handle IO timeouts.

* **cmd/ircserver/main_test.go**
  - Add test cases to cover scenarios involving IO timeouts during message sending.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2389-research/ircserver/pull/17?shareId=651de6b6-7a99-4ee4-92b2-64d6a7b4c8bd).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added retry mechanism for message sending with configurable max retries and delay
	- Introduced configuration parameters for retry behavior

- **Tests**
	- Added test case to validate message logging with retry logic

- **Bug Fixes**
	- Improved error handling for message transmission by implementing retry strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->