### PR TITLE
Refactor server and channel locking strategy to avoid potential deadlocks

### DIFF
--- a/internal/server/channel.go
+++ b/internal/server/channel.go
@@ -105,19 +105,19 @@ func NewChannel(name string) *Channel {
 // AddClient adds a client to the channel with specified mode.
 func (ch *Channel) AddClient(client *Client, mode UserMode) {
 	ch.mu.Lock()
-	defer ch.mu.Unlock()
 	ch.Members[client.nick] = &ChannelMember{
 		Client: client,
 		Mode:   mode,
 	}
+	ch.mu.Unlock()
 	log.Printf("INFO: Client %s joined channel %s with mode %v", client.nick, ch.Name, mode)
 }
 
 // RemoveClient removes a client from the channel.
 func (ch *Channel) RemoveClient(nickname string) {
 	ch.mu.Lock()
-	defer ch.mu.Unlock()
 	delete(ch.Members, nickname)
+	ch.mu.Unlock()
 	log.Printf("INFO: Client %s left channel %s", nickname, ch.Name)
 
 	// If channel is empty, it should be cleaned up by the server
@@ -129,8 +129,8 @@ func (ch *Channel) RemoveClient(nickname string) {
 // SetTopic sets the channel topic.
 func (ch *Channel) SetTopic(topic string) {
 	ch.mu.Lock()
-	defer ch.mu.Unlock()
 	ch.Topic = topic
+	ch.mu.Unlock()
 }
 
 // GetTopic returns the channel topic.


### PR DESCRIPTION
Fixes #40

Refactor the server and channel locking strategy to avoid potential deadlocks.

* Define a strict lock hierarchy (server -> channel) in `internal/server/server.go` and `internal/server/channel.go`.
* Remove nested lock calls in `AddClient`, `RemoveClient`, `SetTopic`, and `handleJoin`, `handlePart`, `deliverMessage` functions.
* Minimize lock duration by copying needed data under a lock and releasing the lock before further processing.
* Add unit tests in `internal/server/server_test.go` and `internal/server/channel_test.go` to simulate concurrent channel joins, leaves, and message deliveries to validate safe operation.
* Add comments to highlight how lock duration is minimized.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/2389-research/ircserver/pull/50?shareId=b0b59030-a99c-4bf0-a0ad-d4bdc7899876).